### PR TITLE
Split project instructions into ADRs

### DIFF
--- a/docs/adr/0001-foundation-platform.md
+++ b/docs/adr/0001-foundation-platform.md
@@ -1,0 +1,27 @@
+# ADR 0001: Choose Next.js and TypeScript for the Schedule Viewer
+
+## Status
+Accepted
+
+## Context
+The schedule viewer should feel like a modern web application with fast
+navigation, client-side interactivity, and the ability to statically
+pre-render recurring event data. We need a framework that is popular,
+well-documented, and supports hybrid static and server rendering so that
+we can ship quickly while keeping the door open for future integrations.
+
+## Decision
+We will build the web client with Next.js using TypeScript. Next.js gives
+us an opinionated React runtime with file-system routing, API routes for
+lightweight back-end needs, and an ecosystem of examples and deployment
+options. TypeScript provides static type checking to document data shapes
+and catch regressions early.
+
+## Consequences
+* We can render the schedule statically and hydrate interactive widgets
+  on the client without writing custom tooling.
+* Team members familiar with React can contribute immediately, reducing
+  onboarding time.
+* We accept the build tooling that comes with Next.js (Webpack and
+  SWC). Migrating to a different stack later would require rewriting the
+  routing and data-loading code.

--- a/docs/adr/0002-schedule-data-format.md
+++ b/docs/adr/0002-schedule-data-format.md
@@ -1,0 +1,26 @@
+# ADR 0002: Store schedule content as Markdown-enhanced YAML
+
+## Status
+Accepted
+
+## Context
+Event sessions include structured fields such as time and room, but also
+need rich text descriptions. Content editors should be able to make quick
+changes in version control without a custom CMS. A pure JSON structure is
+difficult to review, whereas Markdown alone cannot express start times or
+filters.
+
+## Decision
+We will author schedule data in YAML files with embedded Markdown for the
+descriptive fields. Each session entry will include typed keys (id,
+start, end, speakers, tags) alongside a `details` field rendered from
+Markdown. Build tooling will convert the YAML to typed TypeScript objects
+at compile time.
+
+## Consequences
+* Editors can update schedules using any text editor, with YAML providing
+  clear key/value semantics and Markdown preserving formatting.
+* The repository history reflects content changes, enabling meaningful
+  code reviews.
+* We must validate YAML structure during CI to prevent malformed files,
+  and we accept the risk of indentation errors inherent to YAML.

--- a/docs/adr/0003-timezone-handling.md
+++ b/docs/adr/0003-timezone-handling.md
@@ -1,0 +1,26 @@
+# ADR 0003: Normalize schedule times to UTC with localized display
+
+## Status
+Accepted
+
+## Context
+Conference planners and speakers operate across time zones. Persisting
+local times without context leads to ambiguity when generating iCalendar
+files or exposing the schedule through APIs. We need a consistent internal
+representation while still rendering times in the event's local zone for
+attendees.
+
+## Decision
+All event timestamps will be stored and processed as UTC instants. The
+application will also record the canonical event time zone (e.g.,
+`America/Chicago`) and use it to format times for display. When importing
+external data, we will normalize to UTC at the boundary of the ingestion
+process.
+
+## Consequences
+* Calculations such as sorting, duration math, and ICS exports are
+  simplified because the application operates on UTC instants.
+* The UI layer must format and present times in the event's local zone to
+  avoid user confusion.
+* Developers need to be vigilant when accepting user input to ensure it is
+  captured with an explicit zone before conversion to UTC.

--- a/docs/adr/0004-deployment-hosting.md
+++ b/docs/adr/0004-deployment-hosting.md
@@ -1,0 +1,25 @@
+# ADR 0004: Deploy the schedule viewer with static exports on Vercel
+
+## Status
+Accepted
+
+## Context
+The project should be easy to host with minimal operational overhead. The
+schedule is mostly static, with updates happening through Git pushes.
+Continuous delivery and preview environments are important for reviewing
+content updates with stakeholders.
+
+## Decision
+We will deploy the application using Next.js static exports hosted on
+Vercel. Each commit to the default branch will trigger a build that
+produces a static site. Pull requests receive preview deployments so
+stakeholders can verify schedule changes before merging.
+
+## Consequences
+* Hosting costs remain low because the output is a collection of static
+  assets served by Vercel's CDN.
+* Build times become part of the content editing workflow; large data sets
+  may increase publication latency.
+* Any future server-side functionality will require moving to hybrid
+  rendering or an auxiliary service because pure static exports cannot
+  execute server code.

--- a/docs/project-instructions.md
+++ b/docs/project-instructions.md
@@ -1,0 +1,13 @@
+# Project Instructions
+
+The detailed architectural guidance for the schedule viewer is now
+captured as Architecture Decision Records (ADRs). Review the ADRs for the
+rationale behind each core decision:
+
+1. [ADR 0001 – Choose Next.js and TypeScript for the Schedule Viewer](adr/0001-foundation-platform.md)
+2. [ADR 0002 – Store schedule content as Markdown-enhanced YAML](adr/0002-schedule-data-format.md)
+3. [ADR 0003 – Normalize schedule times to UTC with localized display](adr/0003-timezone-handling.md)
+4. [ADR 0004 – Deploy the schedule viewer with static exports on Vercel](adr/0004-deployment-hosting.md)
+
+Future project decisions should be added as new ADRs within the `docs/adr`
+directory so that the team can track the evolution of the architecture.


### PR DESCRIPTION
## Summary
- replace the legacy project instructions with an index that points to new ADRs
- capture key decisions about the stack, data format, time handling, and deployment as dedicated ADR documents

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e52547100c832c8222b0c6767b07ed