### PR TITLE
Fix weekend and holiday cell backgrounds

### DIFF
--- a/src/app/_components/ScheduleGrid.tsx
+++ b/src/app/_components/ScheduleGrid.tsx
@@ -102,7 +102,7 @@ export function ScheduleGrid({ data, density }: ScheduleGridProps) {
                 return (
                   <div
                     key={`${person.id}-${day}`}
-                    className={`grid-cell ${cellPadding} ${cellHeight} flex items-center justify-center ${textSize} font-medium border-b border-border`}
+                    className={`grid-cell ${bgClass} ${cellPadding} ${cellHeight} flex items-center justify-center ${textSize} font-medium border-b border-border`}
                   >
                     {code && (
                       <div

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,14 +18,14 @@
   position: sticky;
   top: 0;
   z-index: 20;
-  background: white;
+  @apply bg-card;
 }
 
 .grid-first-col {
   position: sticky;
   left: 0;
   z-index: 10;
-  background: white;
+  @apply bg-card;
 }
 
 .grid-header.grid-first-col {
@@ -33,13 +33,5 @@
 }
 
 .grid-cell {
-  @apply p-2 bg-white text-center;
-}
-
-.grid-cell-weekend {
-  @apply bg-gray-50;
-}
-
-.grid-cell-holiday {
-  @apply bg-blue-50;
+  @apply text-center;
 }


### PR DESCRIPTION
## Summary
- ensure schedule cells include the computed background class so weekend and holiday styling appears
- adjust sticky grid styles to rely on Tailwind utilities for consistent card backgrounds across density settings

## Testing
- npm run lint *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e52e3d547c832ca1ec0b724a2a6b1f