### PR TITLE
Parse shift code dictionary from env

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { getCurrentYM, isValidYM } from '@/lib/date'
 import { useMonthShifts } from '@/lib/api-client'
+import { shiftCodeMap } from '@/lib/shift-code-map'
 import { MonthNav } from './_components/MonthNav'
 import { DensityToggle, type Density } from './_components/DensityToggle'
 import { LegendCard } from './_components/LegendCard'
@@ -70,7 +71,7 @@ function PageContent() {
         {data && !error && (
           <div className="space-y-4">
             {/* Legend */}
-            <LegendCard codes={data.codes || []} />
+            <LegendCard codes={data.codes || []} codeMap={shiftCodeMap} />
 
             {/* Grid */}
             {data.people.length > 0 ? (

--- a/src/lib/shift-code-map.ts
+++ b/src/lib/shift-code-map.ts
@@ -1,0 +1,41 @@
+import type { ShiftCodeMap } from './types'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseShiftCodeDict(raw: string | undefined): ShiftCodeMap {
+  if (!raw) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+
+    if (!isRecord(parsed)) {
+      console.warn('NEXT_PUBLIC_SHIFT_CODE_DICT must be a JSON object')
+      return {}
+    }
+
+    const entries = Object.entries(parsed)
+    const validEntries = entries.reduce<ShiftCodeMap>((acc, [code, value]) => {
+      if (isRecord(value) && typeof value.label === 'string') {
+        acc[code] = { label: value.label }
+      } else {
+        console.warn(
+          `Ignoring invalid shift code entry for "${code}" in NEXT_PUBLIC_SHIFT_CODE_DICT`
+        )
+      }
+      return acc
+    }, {})
+
+    return validEntries
+  } catch (error) {
+    console.warn('Failed to parse NEXT_PUBLIC_SHIFT_CODE_DICT:', error)
+    return {}
+  }
+}
+
+export const shiftCodeMap: ShiftCodeMap = parseShiftCodeDict(
+  process.env.NEXT_PUBLIC_SHIFT_CODE_DICT
+)


### PR DESCRIPTION
## Summary
- parse NEXT_PUBLIC_SHIFT_CODE_DICT into a typed shift code map with validation and warnings
- propagate the parsed map to the legend so shift labels use configured names

## Testing
- npm run lint *(fails: next not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e52e3a9c58832c82272d42fe014586