### PR TITLE
Improve schedule grid layout and color palette

### DIFF
--- a/src/app/_components/ScheduleGrid.tsx
+++ b/src/app/_components/ScheduleGrid.tsx
@@ -32,14 +32,14 @@ export function ScheduleGrid({ data, density }: ScheduleGridProps) {
   }, [daysInMonth])
 
   // Cell size based on density
-  const cellPadding = density === 'compact' ? 'p-1' : 'p-2'
-  const cellHeight = density === 'compact' ? 'h-8' : 'h-12'
-  const textSize = density === 'compact' ? 'text-xs' : 'text-sm'
+  const cellPadding = density === 'compact' ? 'px-2 py-1' : 'px-3 py-2'
+  const cellHeight = density === 'compact' ? 'h-9' : 'h-14'
+  const textSize = density === 'compact' ? 'text-[11px]' : 'text-sm'
 
   return (
     <div
       ref={parentRef}
-      className="schedule-grid-container border border-border rounded-lg overflow-auto max-h-[600px]"
+      className="schedule-grid-container border border-border rounded-lg overflow-auto max-h-[600px] shadow-sm"
       style={{ '--days-count': daysInMonth } as React.CSSProperties}
     >
       <div
@@ -50,15 +50,21 @@ export function ScheduleGrid({ data, density }: ScheduleGridProps) {
         }}
       >
         {/* Header Row */}
-        <div className={`grid-header grid-first-col ${cellPadding} ${cellHeight} flex items-center font-semibold bg-card border-b border-border`}>
+        <div
+          className={`grid-header grid-first-col ${cellPadding} ${cellHeight} flex items-center font-semibold border-b border-r border-border bg-white/95 backdrop-blur`}
+        >
           Nome
         </div>
         {dayHeaders.map((day) => (
           <div
             key={`header-${day}`}
-            className={`grid-header ${cellPadding} ${cellHeight} flex items-center justify-center font-semibold ${textSize} ${
-              isWeekend(ym, day) ? 'bg-muted' : 'bg-card'
-            } ${isItalianHoliday(ym, day) ? 'bg-accent' : ''} border-b border-border`}
+            className={`grid-header ${cellPadding} ${cellHeight} flex items-center justify-center font-semibold ${textSize} border-b border-border border-r last:border-r-0 ${
+              isItalianHoliday(ym, day)
+                ? 'bg-holiday text-holiday-foreground'
+                : isWeekend(ym, day)
+                ? 'bg-weekend text-foreground'
+                : 'bg-surface'
+            }`}
           >
             {day}
           </div>
@@ -83,7 +89,7 @@ export function ScheduleGrid({ data, density }: ScheduleGridProps) {
             >
               {/* Person Name Cell */}
               <div
-                className={`grid-first-col ${cellPadding} ${cellHeight} flex items-center font-medium bg-card border-b border-border truncate`}
+                className={`grid-first-col ${cellPadding} ${cellHeight} flex items-center font-semibold border-b border-r border-border bg-white/95 backdrop-blur truncate text-[13px] uppercase tracking-wide text-muted-foreground`}
                 title={person.name}
               >
                 {person.name}
@@ -95,18 +101,20 @@ export function ScheduleGrid({ data, density }: ScheduleGridProps) {
                 const isWeekendDay = isWeekend(ym, day)
                 const isHoliday = isItalianHoliday(ym, day)
 
-                let bgClass = 'bg-card'
-                if (isWeekendDay) bgClass = 'bg-muted'
-                if (isHoliday) bgClass = 'bg-accent'
-
                 return (
                   <div
                     key={`${person.id}-${day}`}
-                    className={`grid-cell ${cellPadding} ${cellHeight} flex items-center justify-center ${textSize} font-medium border-b border-border`}
+                    className={`grid-cell ${cellPadding} ${cellHeight} flex items-center justify-center ${textSize} font-semibold border-b border-r border-border last:border-r-0 ${
+                      isHoliday
+                        ? 'bg-holiday'
+                        : isWeekendDay
+                        ? 'bg-weekend'
+                        : 'bg-surface'
+                    }`}
                   >
                     {code && (
                       <div
-                        className="px-1.5 py-0.5 rounded"
+                        className="px-2 py-0.5 rounded-md shadow-sm ring-1 ring-black/5"
                         style={{
                           backgroundColor: getShiftColor(code).background,
                           color: getShiftColor(code).text,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,29 +17,42 @@
 .grid-header {
   position: sticky;
   top: 0;
-  z-index: 20;
-  background: white;
+  z-index: 30;
 }
 
 .grid-first-col {
   position: sticky;
   left: 0;
-  z-index: 10;
-  background: white;
+  z-index: 20;
 }
 
 .grid-header.grid-first-col {
-  z-index: 30;
+  z-index: 40;
 }
 
 .grid-cell {
-  @apply p-2 bg-white text-center;
+  @apply text-center;
 }
 
-.grid-cell-weekend {
-  @apply bg-gray-50;
+:root {
+  --surface: 255 255 255;
+  --surface-muted: 248 250 252;
+  --surface-highlight: 233 244 255;
+  --surface-strong: 15 23 42;
 }
 
-.grid-cell-holiday {
-  @apply bg-blue-50;
+.bg-surface {
+  background-color: rgb(var(--surface));
+}
+
+.bg-weekend {
+  background-color: rgb(var(--surface-muted));
+}
+
+.bg-holiday {
+  background-color: rgb(var(--surface-highlight));
+}
+
+.text-holiday-foreground {
+  color: rgb(37 99 235);
 }

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -19,19 +19,36 @@ function hashCode(str: string): number {
  * Returns { background, text } with accessible contrast
  */
 export function getShiftColor(code: string): { background: string; text: string } {
-  // Common shift codes can have predefined colors
-  const predefinedColors: Record<string, { background: string; text: string }> = {
-    D: { background: 'hsl(43, 74%, 86%)', text: 'hsl(43, 74%, 16%)' }, // Day - Yellow
-    N: { background: 'hsl(231, 48%, 78%)', text: 'hsl(231, 48%, 8%)' }, // Night - Blue
-    O: { background: 'hsl(0, 0%, 95%)', text: 'hsl(0, 0%, 20%)' }, // Off - Gray
-    SM: { background: 'hsl(173, 58%, 79%)', text: 'hsl(173, 58%, 9%)' }, // Smonto - Teal
-    F: { background: 'hsl(0, 0%, 95%)', text: 'hsl(0, 0%, 20%)' }, // Ferie (Vacation) - Gray
-    M: { background: 'hsl(270, 50%, 82%)', text: 'hsl(270, 50%, 12%)' }, // Malattia (Sick) - Purple
-    R: { background: 'hsl(120, 40%, 85%)', text: 'hsl(120, 40%, 15%)' }, // Riposo - Green
+  const normalizedCode = code.toUpperCase()
+
+  const curatedPalette: Record<string, { background: string; text: string }> = {
+    REP: { background: '#dcd6ff', text: '#4338ca' }, // Reperibilità - Indigo
+    RA: { background: '#fde68a', text: '#92400e' }, // Reparto/Pronto - Amber
+    OT: { background: '#bfede6', text: '#0f766e' }, // Ortopedia/Turno OT - Teal
+    FT: { background: '#c7d2fe', text: '#312e81' }, // Formazione - Periwinkle
+    SM: { background: '#99f6e4', text: '#0f766e' }, // Smonto - Aqua
+    V: { background: '#fed7aa', text: '#9a3412' }, // Ferie/Vacanza - Apricot
+    P: { background: '#fbcfe8', text: '#9d174d' }, // Permessi - Pink
+    N: { background: '#c7d2fe', text: '#1e3a8a' }, // Night - Blue
+    D: { background: '#fef3c7', text: '#92400e' }, // Day - Soft Yellow
+    R: { background: '#bbf7d0', text: '#166534' }, // Riposo - Mint
+    F: { background: '#e5e7eb', text: '#1f2937' }, // Festivo - Cool Gray
+    M: { background: '#e9d5ff', text: '#6b21a8' }, // Malattia - Lavender
+    ORT: { background: '#fee2e2', text: '#b91c1c' }, // Ortopedia - Rose
+    OB: { background: '#fde2ff', text: '#a21caf' }, // Ostetricia - Magenta
+    G: { background: '#e0f2fe', text: '#0369a1' }, // Guardia - Sky
   }
 
-  if (predefinedColors[code]) {
-    return predefinedColors[code]
+  const paletteKeys = Object.keys(curatedPalette).sort((a, b) => b.length - a.length)
+
+  for (const key of paletteKeys) {
+    if (normalizedCode.startsWith(key)) {
+      return curatedPalette[key]
+    }
+  }
+
+  if (curatedPalette[normalizedCode]) {
+    return curatedPalette[normalizedCode]
   }
 
   // Generate color from hash


### PR DESCRIPTION
## Summary
- make the schedule grid header row and doctor column sticky while refining spacing and borders
- update global styles to support translucent surfaces that match the reference layout
- curate a shift color palette so recurring codes align with the sample scheme while keeping deterministic fallbacks

## Testing
- npm run lint *(fails: requires interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68e52edbdbc4832c8950732fc3f7c4f4