### PR TITLE
Persist schedule preferences; make DensityToggle controlled and add telemetry + storage

### DIFF
--- a/src/app/_components/DensityToggle.tsx
+++ b/src/app/_components/DensityToggle.tsx
@@ -1,156 +1,80 @@
 'use client'
 
-import { useState } from 'react'
-import { trackClientEvent } from '@/lib/telemetry'
 import type { Density } from './ScheduleGrid/types'
 import { useTelemetry } from '@/app/providers'
 
 export type { Density }
 
 export interface DensityToggleProps {
-
+  density: Density
   onDensityChange: (density: Density) => void
-
   variant?: 'full' | 'compact' | 'responsive'
-
   className?: string
-
 }
 
-
-
 const densityOptions: Array<{ value: Density; label: string; compactLabel: string; ariaLabel: string }> = [
-
-  { 
-
-    value: 'extra-compact', 
-
-    label: 'Ultra compatta', 
-
+  {
+    value: 'extra-compact',
+    label: 'Ultra compatta',
     compactLabel: 'U',
-
-    ariaLabel: 'Visualizzazione ultra compatta' 
-
+    ariaLabel: 'Visualizzazione ultra compatta',
   },
-
-  { 
-
-    value: 'compact', 
-
-    label: 'Compatta', 
-
+  {
+    value: 'compact',
+    label: 'Compatta',
     compactLabel: 'C',
-
-    ariaLabel: 'Visualizzazione compatta' 
-
+    ariaLabel: 'Visualizzazione compatta',
   },
-
-  { 
-
-    value: 'comfortable', 
-
-    label: 'Confortevole', 
-
+  {
+    value: 'comfortable',
+    label: 'Confortevole',
     compactLabel: 'C+',
-
-    ariaLabel: 'Visualizzazione confortevole' 
-
+    ariaLabel: 'Visualizzazione confortevole',
   },
-
 ]
 
-
-
-export function DensityToggle({ onDensityChange, variant = 'full', className = '' }: DensityToggleProps) {
-
-  const [density, setDensity] = useState<Density>('compact')
-
+export function DensityToggle({ density, onDensityChange, variant = 'full', className = '' }: DensityToggleProps) {
   const { track } = useTelemetry()
 
-
-
   const handleToggle = (newDensity: Density) => {
-
     if (newDensity === density) return
 
-
-
-    setDensity(newDensity)
-
     onDensityChange(newDensity)
-
     track({ feature: 'density_toggle', action: 'change_density', value: newDensity })
-
   }
 
-
-
   return (
-
     <div className={`flex items-center gap-2 ${className}`}>
-
       {(variant === 'full' || variant === 'responsive') && (
-
         <span className={`text-xs text-muted-foreground whitespace-nowrap ${variant === 'responsive' ? 'hidden lg:inline' : ''}`}>
-
           Densità:
-
         </span>
-
       )}
-
       <div className="flex border border-border rounded overflow-hidden bg-background">
-
         {densityOptions.map((option) => (
-
           <button
-
             key={option.value}
-
             onClick={() => handleToggle(option.value)}
-
             className={`px-2 py-1 text-xs transition-colors whitespace-nowrap ${
-
               density === option.value
-
                 ? 'bg-primary text-primary-foreground font-medium'
-
                 : 'bg-background hover:bg-accent text-muted-foreground hover:text-foreground'
-
             } ${variant === 'compact' ? 'min-w-[24px] text-center' : ''} ${variant === 'responsive' ? 'lg:min-w-0 min-w-[24px] text-center lg:text-left' : ''}`}
-
             aria-label={option.ariaLabel}
-
             aria-pressed={density === option.value}
-
             title={option.label}
-
           >
-
             {variant === 'compact' && option.compactLabel}
-
             {variant === 'full' && option.label}
-
             {variant === 'responsive' && (
-
               <>
-
                 <span className="lg:hidden">{option.compactLabel}</span>
-
                 <span className="hidden lg:inline">{option.label}</span>
-
               </>
-
             )}
-
           </button>
-
         ))}
-
       </div>
-
     </div>
-
   )
-
 }

--- a/src/app/_components/ScheduleApp.tsx
+++ b/src/app/_components/ScheduleApp.tsx
@@ -16,6 +16,66 @@ import { useTelemetry } from '@/app/providers'
 import { ViewToggle } from './ViewToggle'
 import { LegendButton } from './LegendButton'
 
+const DENSITY_COOKIE_KEY = 'schedule-density'
+const VIEW_MODE_COOKIE_KEY = 'schedule-view-mode'
+const VIEW_USAGE_STORAGE_KEY = 'schedule-view-usage'
+const PREFERENCE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365
+
+function isDensity(value: string): value is Density {
+  return value === 'extra-compact' || value === 'compact' || value === 'comfortable'
+}
+
+function isViewMode(value: string): value is ViewMode {
+  return value === 'people' || value === 'shifts'
+}
+
+function getCookieValue(key: string): string | null {
+  if (typeof document === 'undefined') return null
+
+  const encodedKey = encodeURIComponent(key)
+  const cookie = document.cookie
+    .split('; ')
+    .find((row) => row.startsWith(`${encodedKey}=`))
+
+  if (!cookie) return null
+  return decodeURIComponent(cookie.split('=').slice(1).join('='))
+}
+
+function setCookieValue(key: string, value: string) {
+  if (typeof document === 'undefined') return
+
+  document.cookie = `${encodeURIComponent(key)}=${encodeURIComponent(value)}; path=/; max-age=${PREFERENCE_COOKIE_MAX_AGE}; samesite=lax`
+}
+
+function getDensityFromCookie(): Density | null {
+  const value = getCookieValue(DENSITY_COOKIE_KEY)
+  return value && isDensity(value) ? value : null
+}
+
+function getViewModeFromCookie(): ViewMode | null {
+  const value = getCookieValue(VIEW_MODE_COOKIE_KEY)
+  return value && isViewMode(value) ? value : null
+}
+
+function incrementViewUsage(viewMode: ViewMode): number | null {
+  if (typeof window === 'undefined') return null
+
+  try {
+    const raw = window.localStorage.getItem(VIEW_USAGE_STORAGE_KEY)
+    const usage = raw ? (JSON.parse(raw) as Partial<Record<ViewMode, number>>) : {}
+    const nextCount = (usage[viewMode] || 0) + 1
+    const nextUsage = {
+      people: viewMode === 'people' ? nextCount : usage.people || 0,
+      shifts: viewMode === 'shifts' ? nextCount : usage.shifts || 0,
+    }
+
+    window.localStorage.setItem(VIEW_USAGE_STORAGE_KEY, JSON.stringify(nextUsage))
+    return nextCount
+  } catch {
+    return null
+  }
+}
+
 interface ScheduleAppProps {
   basePath?: string
 }
@@ -35,6 +95,20 @@ export function ScheduleApp({ basePath = '/' }: ScheduleAppProps) {
   const { data, isLoading, error, refetch } = useMonthShifts(currentYM)
   const { track } = useTelemetry()
 
+  useEffect(() => {
+    const cookieDensity = getDensityFromCookie()
+    if (cookieDensity) {
+      setDensity(cookieDensity)
+      track({ feature: 'density_toggle', action: 'hydrate_density_preference', value: cookieDensity })
+    }
+
+    const cookieViewMode = getViewModeFromCookie()
+    if (cookieViewMode) {
+      setViewMode(cookieViewMode)
+      track({ feature: 'view_toggle', action: 'hydrate_view_mode_preference', value: cookieViewMode })
+    }
+  }, [track])
+
   // Track page view on mount
   useEffect(() => {
     track({ feature: 'schedule_app', action: 'page_view', value: currentYM })
@@ -52,12 +126,22 @@ export function ScheduleApp({ basePath = '/' }: ScheduleAppProps) {
     refetch()
   }, [currentYM, refetch, track])
 
-  const densityChangeHandler = useCallback(
-    (newDensity: Density) => {
-      setDensity(newDensity)
-    },
-    []
-  )
+  const densityChangeHandler = useCallback((newDensity: Density) => {
+    setDensity(newDensity)
+    setCookieValue(DENSITY_COOKIE_KEY, newDensity)
+    track({ feature: 'density_toggle', action: 'persist_density_preference', value: newDensity })
+  }, [track])
+
+  const viewModeChangeHandler = useCallback((newMode: ViewMode) => {
+    setViewMode(newMode)
+    setCookieValue(VIEW_MODE_COOKIE_KEY, newMode)
+    track({ feature: 'view_toggle', action: 'persist_view_mode_preference', value: newMode })
+
+    const usageCount = incrementViewUsage(newMode)
+    if (usageCount !== null) {
+      track({ feature: 'view_toggle', action: 'long_term_usage_count', value: `${newMode}:${usageCount}` })
+    }
+  }, [track])
 
   if (isConfigLoading) {
     return (
@@ -79,22 +163,20 @@ export function ScheduleApp({ basePath = '/' }: ScheduleAppProps) {
           </div>
         )}
 
-        {/* New Responsive Top Bar */}
         <div className="flex flex-col bg-card border-b border-border px-4 py-2 gap-2">
-          {/* Row 1: Nav (Left) + Desktop Controls (Center/Right) + Mobile Feedback (Right) */}
           <div className="flex items-center justify-between gap-2">
             <div className="flex-shrink-0">
               <MonthNav currentYM={currentYM} basePath={basePath} />
             </div>
 
-            {/* Desktop Controls (> 640px) */}
             <div className="hidden sm:flex items-center gap-3">
               <ViewToggle
                 viewMode={viewMode}
-                onToggle={setViewMode}
+                onToggle={viewModeChangeHandler}
                 variant="responsive"
               />
               <DensityToggle
+                density={density}
                 onDensityChange={densityChangeHandler}
                 variant="responsive"
               />
@@ -102,21 +184,20 @@ export function ScheduleApp({ basePath = '/' }: ScheduleAppProps) {
               <FeedbackButton />
             </div>
 
-            {/* Mobile Feedback (< 640px) */}
             <div className="sm:hidden">
               <FeedbackButton />
             </div>
           </div>
 
-          {/* Row 2: Mobile Controls (< 640px) */}
           <div className="flex sm:hidden items-center justify-between gap-2">
             <ViewToggle
               viewMode={viewMode}
-              onToggle={setViewMode}
+              onToggle={viewModeChangeHandler}
               variant="compact"
             />
             <div className="flex items-center gap-2">
               <DensityToggle
+                density={density}
                 onDensityChange={densityChangeHandler}
                 variant="compact"
               />


### PR DESCRIPTION
### Motivation

- Persist user preferences for schedule density and view mode across sessions and track usage for analytics.
- Convert the density toggle to a controlled component so top-level state can be persisted and instrumented.

### Description

- Changed `DensityToggle` to be controlled by accepting a `density` prop and removed its internal `useState`, and cleaned up an unused import; UI labels/formatting preserved.
- Added cookie/localStorage helpers and constants (`DENSITY_COOKIE_KEY`, `VIEW_MODE_COOKIE_KEY`, `VIEW_USAGE_STORAGE_KEY`, `getCookieValue`, `setCookieValue`, `getDensityFromCookie`, `getViewModeFromCookie`, `incrementViewUsage`) to `ScheduleApp` to read and persist preferences and usage counts. 
- Hydrates preferences on mount and updates telemetry events for `hydrate_density_preference`, `hydrate_view_mode_preference`, `persist_density_preference`, `persist_view_mode_preference`, and `long_term_usage_count`, and tracks page/view interactions. 
- Wired new handlers (`densityChangeHandler`, `viewModeChangeHandler`) into `ViewToggle` and `DensityToggle` and set cookies/localStorage when preferences change.

### Testing

- Ran a TypeScript type check with `tsc --noEmit` which completed successfully. 
- Built the app with `npm run build` and ran the existing test suite with `npm test`, and both returned green (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07db1fe3fc832c8889155f1c92bd1f)